### PR TITLE
Origin URL should be defined by server variable

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -33,7 +33,7 @@ const strings = {
     __outname__: project.name,
     __outdir__: project.dir,
     __version__: version,
-    __origin__: project.server || 'https://www.mediawiki.org',
+    __origin__: project.server,
     __styles__: `${ project.scriptPath }/index.php?title=${ project.target }.css&action=raw&ctype=text/css`,
     __messages__: `${ project.scriptPath }/index.php?title=${ project.i18n }$lang.js&action=raw&ctype=text/javascript`,
     __debug__: process.argv.includes( '--start' ),

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -33,14 +33,13 @@ const strings = {
     __outname__: project.name,
     __outdir__: project.dir,
     __version__: version,
-    __origin__: 'https://www.mediawiki.org',
+    __origin__: project.server || 'https://www.mediawiki.org',
     __styles__: `${ project.scriptPath }/index.php?title=${ project.target }.css&action=raw&ctype=text/css`,
     __messages__: `${ project.scriptPath }/index.php?title=${ project.i18n }$lang.js&action=raw&ctype=text/javascript`,
     __debug__: process.argv.includes( '--start' ),
 };
 
 if ( args.start ) {
-    strings.__origin__ = project.server;
     strings.__styles__ = `${ project.target }.css`;
     strings.__messages__ = `${ project.i18n }$lang.js`;
 }


### PR DESCRIPTION
Fix the issue where `mediawiki.org` is always used as the origin URL (e.g. deployed JS will attempt to load the instantDiffs.css from `mediawiki.org` instead of the configured server.